### PR TITLE
Add go mod tidy check to CI pipeline

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -22,11 +22,9 @@ HIy
 HTAP
 IDR
 IExecute
+IPrepare
 IRecord
 IRun
-IPrepare
-Preparex
-Queryx
 KFS
 Kirill
 Kvs
@@ -54,9 +52,12 @@ Patroni
 Percona
 Pmgr
 Postgre
+Preparex
 QDBKR
 QDBTx
+Qdocker
 Qgo
+Queryx
 RAddr
 RFQNIs
 RIR
@@ -268,6 +269,7 @@ golangconf
 gomaxprocs
 gomock
 gomod
+gomodtidy
 goooal
 gorm
 goyacc
@@ -654,4 +656,3 @@ yjoin
 youtube
 yylex
 zerolog
-Qdocker

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  GO_VERSION: 1.24.3
+
 jobs:
   fmtcheck:
     name: go fmt check
@@ -48,3 +51,19 @@ jobs:
         with:
           root-path: './' # The relative root path to run goimports
           excludes: "./yacc/"
+
+  gomodtidy:
+    name: go mod tidy check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: ensure go.mod is tidy
+        run: |
+          go mod tidy
+          DIFF=$(git diff .);
+          if [ -n "$DIFF" ]; then
+            echo "$DIFF" && echo "run 'go mod tidy' and commit the changes" && exit 1;
+          fi

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/cucumber/godog v0.15.1
 	github.com/docker/docker v28.3.3+incompatible
+	github.com/docker/go-connections v0.5.0
 	github.com/go-faster/city v1.0.1
 	github.com/go-ldap/ldap/v3 v3.4.11
 	github.com/gofrs/uuid v4.4.0+incompatible
@@ -55,7 +56,6 @@ require (
 	github.com/cucumber/messages/go/v21 v21.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
-	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,6 @@ github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrB
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/pg-sharding/lyx v0.0.0-20250714175250-724127b45b0f h1:UMcsb2OFFf05ClbBt3yd6VxcQAob0uYyg6F/cibhhPw=
-github.com/pg-sharding/lyx v0.0.0-20250714175250-724127b45b0f/go.mod h1:2dPBQAhqv/30mhzj2yBXQkXhsGJQ8GhM+oWOfbGua58=
 github.com/pg-sharding/lyx v0.0.0-20250802034259-035f2510a593 h1:bC7czasMCxYGmlSQ8QUEYnOeID0aDxL4z+gCAJ1qHdA=
 github.com/pg-sharding/lyx v0.0.0-20250802034259-035f2510a593/go.mod h1:2dPBQAhqv/30mhzj2yBXQkXhsGJQ8GhM+oWOfbGua58=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
- Added a “go mod tidy check” job to the linters workflow so CI runs go mod tidy and fails if go.mod or go.sum change

- Tidied the module files, promoting github.com/docker/go-connections to a direct requirement in go.mod